### PR TITLE
Remove docker username from build output

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -25,6 +25,7 @@ export TEST_FLAGS="-v -parallel 1"
 # not leak.
 redact_secrets() {
   sed "s/$DOCKER_PASSWORD/[REDACTED]/"
+  sed "s/$DOCKER_USERNAME/[REDACTED]/"
 }
 
 log "Building executor"


### PR DESCRIPTION
### Description of the Change

Remove DOCKER_PASSWORD from build logs
